### PR TITLE
Typing

### DIFF
--- a/src/hepler.ts
+++ b/src/hepler.ts
@@ -1,10 +1,15 @@
 import { hasDuplicated } from "./collection";
 import deepEqual from "deep-equal";
-import type { Row_t, cellSymbols, internalSymbols } from "./types";
+import type {
+  conditionsRow,
+  cellSymbols,
+  internalSymbols,
+  headerRow,
+} from "./types";
 
 export const getOutputFromArray = (
-  headers: Row_t,
-  row: Row_t,
+  headers: headerRow,
+  row: conditionsRow,
   symbol: cellSymbols & internalSymbols & { out: Symbol }
 ) => {
   let result: unknown = symbol.undefined;
@@ -22,7 +27,10 @@ export const getOutputFromArray = (
   return result;
 };
 
-export const hasDuplicatedRowExcept = (rows: Row_t[], exceptIndex: number) => {
+export const hasDuplicatedRowExcept = (
+  rows: conditionsRow[],
+  exceptIndex: number
+) => {
   const conditions = rows.map((row) =>
     row.filter((_, index) => index !== exceptIndex)
   );
@@ -30,7 +38,7 @@ export const hasDuplicatedRowExcept = (rows: Row_t[], exceptIndex: number) => {
 };
 
 export const splitConditionsOtherwise = (
-  rows: Row_t[],
+  rows: conditionsRow[],
   symbols: cellSymbols
 ) => {
   const normal = rows.filter((row) => !row.includes(symbols.otherwise));

--- a/src/hepler.ts
+++ b/src/hepler.ts
@@ -1,6 +1,6 @@
 import { hasDuplicated } from "./collection";
 import deepEqual from "deep-equal";
-import { Row_t, cellSymbols, internalSymbols } from "./types";
+import type { Row_t, cellSymbols, internalSymbols } from "./types";
 
 export const getOutputFromArray = (
   headers: Row_t,

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import {
 export class ThinRichTable {
   public out: Symbol;
   public cell: cellSymbols;
-  public internals: internalSymbols;
+  #internals: internalSymbols;
 
   constructor() {
     this.out = Symbol("out");
@@ -24,13 +24,15 @@ export class ThinRichTable {
       any: Symbol("any"),
       otherwise: Symbol("otherwise"),
     };
-    this.internals = {
+    this.#internals = {
+      // `undefined` is used for cell value,
+      // so It be defined "undefined" symbol as internal use.
       undefined: Symbol("undefined"),
     };
   }
 
   #getOutputFromArray(headers: headerRow, row: conditionsRow) {
-    const symbols = { ...this.cell, ...this.internals, out: this.out };
+    const symbols = { ...this.cell, ...this.#internals, out: this.out };
     return getOutputFromArray(headers, row, symbols);
   }
 
@@ -72,7 +74,7 @@ export class ThinRichTable {
     for (const rows of [normalRows, otherwiseRows]) {
       for (const row of rows) {
         const output = this.#getOutputFromArray(headers, row);
-        if (output === this.internals.undefined) continue;
+        if (output === this.#internals.undefined) continue;
         matched.push({ row, output });
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,10 @@
 import { splitArrayAsNLength } from "./collection";
-import type { Row_t, cellSymbols, internalSymbols } from "./types";
+import type {
+  conditionsRow,
+  headerRow,
+  cellSymbols,
+  internalSymbols,
+} from "./types";
 import { TRExceptions } from "./exception";
 import {
   getOutputFromArray,
@@ -24,16 +29,16 @@ export class ThinRichTable {
     };
   }
 
-  #getOutputFromArray(headers: Row_t, row: Row_t) {
+  #getOutputFromArray(headers: headerRow, row: conditionsRow) {
     const symbols = { ...this.cell, ...this.internals, out: this.out };
     return getOutputFromArray(headers, row, symbols);
   }
 
-  #hasDuplicatedConditions(rows: Row_t[], outputIndex: number) {
+  #hasDuplicatedConditions(rows: conditionsRow[], outputIndex: number) {
     return hasDuplicatedRowExcept(rows, outputIndex);
   }
 
-  eval(strings: TemplateStringsArray, ...vars: Row_t) {
+  eval(strings: TemplateStringsArray, ...vars: unknown[]) {
     if (!isCalledAsTagged(strings, vars)) {
       throw TRExceptions.notCalledAsTaggedError;
     }
@@ -53,14 +58,14 @@ export class ThinRichTable {
     }
 
     const splitted = splitArrayAsNLength(vars, columnCount);
-    const headers = splitted[0];
-    const rows = splitted.splice(1);
+    const headers = splitted[0] as headerRow;
+    const rows = splitted.splice(1) as conditionsRow[];
 
     if (this.#hasDuplicatedConditions(rows, columnIndex)) {
       throw TRExceptions.duplicatedConditionError;
     }
 
-    const matched = [] as Array<{ row: unknown[]; output: unknown }>;
+    const matched = [] as Array<{ row: conditionsRow; output: unknown }>;
     const [normalRows, otherwiseRows] = splitConditionsOtherwise(rows, {
       ...this.cell,
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { splitArrayAsNLength } from "./collection";
-import { Row_t, cellSymbols, internalSymbols } from "./types";
+import type { Row_t, cellSymbols, internalSymbols } from "./types";
 import { TRExceptions } from "./exception";
 import {
   getOutputFromArray,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
-export type Row_t = unknown[];
+export type conditionsRow = unknown[] & { readonly __tag: unique symbol };
+export type headerRow = unknown[] & { readonly __tag: unique symbol };
 
 export type cellKeys = "any" | "otherwise";
 export type cellSymbols = { [key in cellKeys]: Symbol };


### PR DESCRIPTION
- `Row_t`としていたテーブルの行の型をヘッダと条件部分で分けた
- 内部でのみ利用する`internals`をプライベートにした
